### PR TITLE
Add development logging for local traffic

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -5,11 +5,13 @@ import { createBooking, cancelBooking, updateBooking } from './routes/booking.js
 import { listBookings } from './routes/bookings.js';
 import { listMedia, streamMedia } from './routes/media.js';
 import { authMiddleware } from './middleware/auth.js';
+import { devLoggerMiddleware } from './middleware/devLogger.js';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use(devLoggerMiddleware());
 
 app.get('/health', (_req, res) => res.status(200).send('ok'));
 

--- a/server/middleware/devLogger.ts
+++ b/server/middleware/devLogger.ts
@@ -1,0 +1,49 @@
+import type { Request, RequestHandler } from 'express';
+
+const LOCAL_ADDRESS_SET = new Set(['127.0.0.1', '::1']);
+
+const normalizeAddress = (address: string): string => {
+  if (!address) {
+    return '';
+  }
+  return address.startsWith('::ffff:') ? address.slice(7) : address;
+};
+
+const isLocalRequest = (req: Request): boolean => {
+  const hostHeader = req.headers.host?.toLowerCase() ?? '';
+  const remoteAddress = normalizeAddress(req.socket.remoteAddress ?? '');
+  const clientIp = normalizeAddress(req.ip ?? '');
+
+  if (hostHeader.startsWith('localhost') || hostHeader.startsWith('127.0.0.1')) {
+    return true;
+  }
+
+  if (LOCAL_ADDRESS_SET.has(remoteAddress) || LOCAL_ADDRESS_SET.has(clientIp)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const devLoggerMiddleware = (): RequestHandler => {
+  const shouldLog = process.env.NODE_ENV !== 'production';
+
+  return (req, res, next) => {
+    if (!shouldLog || !isLocalRequest(req)) {
+      next();
+      return;
+    }
+
+    const startTime = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
+      const remoteAddress = normalizeAddress(req.socket.remoteAddress ?? '');
+      console.log(
+        `[dev] ${req.method} ${req.originalUrl} -> ${res.statusCode} (${durationMs.toFixed(2)}ms) from ${remoteAddress || 'unknown'}`,
+      );
+    });
+
+    next();
+  };
+};


### PR DESCRIPTION
## Summary
- add a development logger middleware that records localhost traffic when not in production
- register the middleware in the Express app so local requests are printed with duration and status

## Testing
- npm run build *(fails: TypeScript cannot find module 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_68fa6548e5ac8333877831491cdd4a5f