### PR TITLE
Align auth middleware with gateway header contract

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -14,51 +14,81 @@ export interface AuthenticatedUser {
   uid: string;
   email: string | null;
   claims: JWTPayload;
+  /** The original token if present (may be null behind API Gateway). */
   token: string | null;
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       user?: AuthenticatedUser;
+      /** Your *app* JWT from the x-app-jwt header. */
       appJwt?: string | null;
     }
   }
 }
 
-const appleJWKS = createRemoteJWKSet(new URL('https://appleid.apple.com/auth/keys'));
-const googleJWKS = createRemoteJWKSet(new URL('https://www.googleapis.com/oauth2/v3/certs'));
+const appleJWKS = createRemoteJWKSet(
+  new URL('https://appleid.apple.com/auth/keys'),
+);
+const googleJWKS = createRemoteJWKSet(
+  new URL('https://www.googleapis.com/oauth2/v3/certs'),
+);
 
 const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
 const APPLE_ISSUER = 'https://appleid.apple.com';
 
+const GOOGLE_AUDIENCES: string[] = [
+  '379484922687-q7ge8kg89o0vi1gn1lkjaqciu8e8e3eb.apps.googleusercontent.com',
+  '379484922687-j3bc9264v49hpqloi98897jbfg0acjjm.apps.googleusercontent.com',
+];
+
 const textEncoder = new TextEncoder();
 
-function extractBearer(headerValue: string | undefined | null): string | null {
+function extractBearer(headerValue?: string | null): string | null {
   if (!headerValue) return null;
   const match = /^Bearer\s+(.+)$/i.exec(headerValue.trim());
   return match ? match[1] : null;
 }
 
-function extractHeaderToken(headerValue: string | undefined | null): string | null {
-  if (!headerValue) return null;
-  const trimmed = headerValue.trim();
-  if (!trimmed) return null;
-  const withoutBearer = trimmed.replace(/^Bearer\s+/i, '');
-  return withoutBearer.replace(/^"+|"+$/g, '') || null;
-}
-
-function decodeBase64Url(value: string): string {
+function decodeBase64UrlToUtf8(value: string): string {
   const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
   const padding = normalized.length % 4;
   const padded = padding ? normalized + '='.repeat(4 - padding) : normalized;
   return Buffer.from(padded, 'base64').toString('utf8');
 }
 
+function normalizeSubject(payload: JWTPayload): string {
+  const subject = typeof payload.sub === 'string' ? payload.sub : null;
+  if (!subject) {
+    throw new Error('Token is missing subject (sub).');
+  }
+  return subject;
+}
+
+function detectProviderFromToken(token: string): Provider {
+  const header = decodeProtectedHeader(token);
+  const alg = header.alg ? String(header.alg) : '';
+  if (alg.toUpperCase().startsWith('HS')) {
+    return 'session';
+  }
+
+  const payload = decodeJwt(token);
+  const issuer = typeof payload.iss === 'string' ? payload.iss : '';
+  if (GOOGLE_ISSUERS.includes(issuer)) {
+    return 'google';
+  }
+  if (issuer === APPLE_ISSUER) {
+    return 'apple';
+  }
+  throw new Error(`Unknown token issuer: ${issuer}`);
+}
+
 async function verifyApple(idToken: string) {
   const { payload } = await jwtVerify(idToken, appleJWKS, {
     issuer: APPLE_ISSUER,
-    audience: process.env.APPLE_AUDIENCE_BUNDLE_ID,
+    audience: process.env.APPLE_AUDIENCE_BUNDLE_ID ?? 'com.innerpeace.app',
     algorithms: ['RS256'],
   });
   return payload;
@@ -67,7 +97,7 @@ async function verifyApple(idToken: string) {
 async function verifyGoogle(idToken: string) {
   const { payload } = await jwtVerify(idToken, googleJWKS, {
     issuer: GOOGLE_ISSUERS,
-    audience: process.env.GOOGLE_OAUTH_CLIENT_ID,
+    audience: GOOGLE_AUDIENCES,
     algorithms: ['RS256'],
   });
   return payload;
@@ -84,41 +114,23 @@ async function verifySession(idToken: string) {
   return payload;
 }
 
-function normalizeSubject(payload: JWTPayload): string {
-  const subject = (payload.sub ?? (payload as any).user_id ?? '').toString();
-  if (!subject) {
-    throw new Error('Token is missing subject');
-  }
-  return subject;
-}
-
-function detectProviderFromToken(token: string): Provider {
-  const header = decodeProtectedHeader(token);
-  if (header.alg && header.alg.toUpperCase().startsWith('HS')) {
-    return 'session';
-  }
-
-  const payload = decodeJwt(token);
-  const issuer = typeof payload.iss === 'string' ? payload.iss : '';
-  if (GOOGLE_ISSUERS.includes(issuer)) {
-    return 'google';
-  }
-  if (issuer === APPLE_ISSUER) {
-    return 'apple';
-  }
-  throw new Error('Unknown token issuer');
-}
-
-export async function authHandler(req: Request, res: Response, next: NextFunction) {
+export async function authHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
-    const authorizationBearer = extractBearer(req.header('authorization'));
-    const googleHeaderToken = extractHeaderToken(req.header('x-google-id-token'));
-    const appleHeaderToken = extractHeaderToken(req.header('x-apple-identity-token'));
+    const appJwtHeader = req.header('x-app-jwt');
+    const appJwt = appJwtHeader ? appJwtHeader.trim() || null : null;
+    req.appJwt = appJwt;
 
     const gatewayUserInfo = req.header('x-endpoint-api-userinfo');
     if (gatewayUserInfo) {
       try {
-        const claims = JSON.parse(decodeBase64Url(gatewayUserInfo)) as JWTPayload;
+        const claims = JSON.parse(
+          decodeBase64UrlToUtf8(gatewayUserInfo),
+        ) as JWTPayload;
+
         const issuer = typeof claims.iss === 'string' ? claims.iss : '';
         const provider: Provider = GOOGLE_ISSUERS.includes(issuer)
           ? 'google'
@@ -134,60 +146,65 @@ export async function authHandler(req: Request, res: Response, next: NextFunctio
           uid,
           email,
           claims,
-          token: provider === 'google' ? googleHeaderToken : provider === 'apple' ? appleHeaderToken : authorizationBearer,
+          token: null,
         };
-        req.appJwt = authorizationBearer;
         return next();
       } catch (err) {
-        console.error('[auth] failed to parse X-Endpoint-API-UserInfo header', err);
+        // eslint-disable-next-line no-console
+        console.warn('[auth] failed to parse X-Endpoint-API-UserInfo:', err);
       }
     }
 
     const providerHeader = (req.header('x-auth-provider') || '').toLowerCase();
+    const authorizationToken = extractBearer(req.header('authorization'));
 
     let provider: Provider | null = null;
-    let token: string | null = null;
+    let tokenForVerification: string | null = null;
 
-    if (providerHeader === 'apple') {
-      provider = 'apple';
-      token = appleHeaderToken || authorizationBearer;
-    } else if (providerHeader === 'google') {
-      provider = 'google';
-      token = googleHeaderToken || authorizationBearer;
-    } else if (providerHeader === 'session') {
+    if (providerHeader === 'session') {
+      if (!appJwt) {
+        return res.status(401).json({ message: 'Jwt is missing', code: 401 });
+      }
       provider = 'session';
-      token = authorizationBearer;
-    } else if (appleHeaderToken) {
-      provider = 'apple';
-      token = appleHeaderToken;
-    } else if (googleHeaderToken) {
-      provider = 'google';
-      token = googleHeaderToken;
-    } else if (authorizationBearer) {
-      provider = detectProviderFromToken(authorizationBearer);
-      token = authorizationBearer;
-    }
-
-    if (!provider || !token) {
-      return res.status(401).json({ message: 'Missing authentication token', code: 401 });
-    }
-
-    let payload: JWTPayload;
-    if (provider === 'apple') {
-      payload = await verifyApple(token);
-    } else if (provider === 'google') {
-      payload = await verifyGoogle(token);
+      tokenForVerification = appJwt;
     } else {
-      payload = await verifySession(token);
+      if (!authorizationToken) {
+        return res.status(401).json({ message: 'Jwt is missing', code: 401 });
+      }
+
+      if (providerHeader === 'google') {
+        provider = 'google';
+      } else if (providerHeader === 'apple') {
+        provider = 'apple';
+      } else {
+        provider = detectProviderFromToken(authorizationToken);
+        if (provider === 'session') {
+          return res.status(401).json({ message: 'Jwt is missing', code: 401 });
+        }
+      }
+      tokenForVerification = authorizationToken;
     }
 
-    const uid = normalizeSubject(payload);
-    const email = typeof payload.email === 'string' ? payload.email : null;
+    if (!provider || !tokenForVerification) {
+      return res.status(401).json({ message: 'Jwt is missing', code: 401 });
+    }
 
-    req.user = { provider, uid, email, claims: payload, token };
-    req.appJwt = authorizationBearer;
+    let claims: JWTPayload;
+    if (provider === 'google') {
+      claims = await verifyGoogle(tokenForVerification);
+    } else if (provider === 'apple') {
+      claims = await verifyApple(tokenForVerification);
+    } else {
+      claims = await verifySession(tokenForVerification);
+    }
+
+    const uid = normalizeSubject(claims);
+    const email = typeof claims.email === 'string' ? claims.email : null;
+
+    req.user = { provider, uid, email, claims, token: tokenForVerification };
     return next();
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('[auth] token verification failed', error);
     return res.status(401).json({ message: 'Invalid token', code: 401 });
   }

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { authHandler } from '../middleware/auth.js';
 import { driveClientFromRequest } from '../utils/googleClient.js';
 
 const DEFAULT_ALLOWED = ['video/*', 'audio/*'];
@@ -12,7 +13,7 @@ function isAllowed(mimeType: string | undefined | null, allowed: string[]): bool
 
 const router = Router();
 
-router.get('/list', async (req, res) => {
+router.get('/list', authHandler, async (req, res) => {
   try {
     const folderId = String(
       req.query.folderId || process.env.DRIVE_MEDIA_FOLDER_ID || process.env.DRIVE_PARENT_FOLDER_ID || '',


### PR DESCRIPTION
## Summary
- read the application session token from the x-app-jwt header and reserve Authorization for ID tokens while trusting gateway user info
- streamline provider detection without legacy headers and require authentication on the media list endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ed7f8ae8833390dcbc27dad520b6