### PR TITLE
Fix runtime entrypoint path after TypeScript emit changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY package*.json ./
 EXPOSE 8080
-# With tsconfig { rootDir: "server", outDir: "dist" }, the entry is dist/index.js
-CMD ["node","dist/index.js"]
+# With server sources emitted under dist/server/, the entry is dist/server/index.js
+CMD ["node","dist/server/index.js"]

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "innerpeace-api",
   "version": "1.0.0",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/server/index.js",
   "scripts": {
     "prestart": "npm run build",
     "dev": "tsx watch server/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node dist/server/index.js",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- point the package entry and start script at the compiled dist/server/index.js file
- update the Docker runtime command to match the new TypeScript output structure

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6901fe20087c8333813ceb2c333d9b07