### PR TITLE
Refine Google service account clients

### DIFF
--- a/server/routes/availability.ts
+++ b/server/routes/availability.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { getCalendarClient } from '../utils/googleClient.js';
+import { getCalendarClient } from '../utils/googleCalendar.js';
 import { requireUser } from '../middleware/auth.js';
 import { targetCalendarId } from '../config/environment.js';
 

--- a/server/routes/booking.ts
+++ b/server/routes/booking.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
 import type { calendar_v3 } from 'googleapis';
-import { getCalendarClient } from '../utils/googleClient.js';
+import { getCalendarClient } from '../utils/googleCalendar.js';
 import { requireUser } from '../middleware/auth.js';
 import config, { targetCalendarId } from '../config/environment.js';
 import { pickMeetUrl } from '../utils/events.js';

--- a/server/routes/bookings.ts
+++ b/server/routes/bookings.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
 import type { calendar_v3 } from 'googleapis';
-import { getCalendarClient } from '../utils/googleClient.js';
+import { getCalendarClient } from '../utils/googleCalendar.js';
 import { requireUser } from '../middleware/auth.js';
 import { targetCalendarId } from '../config/environment.js';
 import { pickMeetUrl } from '../utils/events.js';

--- a/server/utils/googleCalendar.ts
+++ b/server/utils/googleCalendar.ts
@@ -1,0 +1,12 @@
+import { google } from 'googleapis';
+import { getSaJwt } from './googleClient.js';
+
+const CAL_SCOPES = [
+  'https://www.googleapis.com/auth/calendar.readonly',
+  'https://www.googleapis.com/auth/calendar.events',
+];
+
+export function getCalendarClient() {
+  const auth = getSaJwt(CAL_SCOPES);
+  return google.calendar({ version: 'v3', auth });
+}

--- a/server/utils/googleClient.ts
+++ b/server/utils/googleClient.ts
@@ -1,13 +1,26 @@
-import { google } from 'googleapis';
-import { googleAuth } from '../../src/services/googleClient.js';
+import { JWT } from 'google-auth-library';
 
-const CALENDAR_SCOPES = [
-  'https://www.googleapis.com/auth/calendar',
-  'https://www.googleapis.com/auth/calendar.events',
-];
+function normalizeKey(k: string) {
+  const normalized = k.trim().replace(/\\n/g, '\n');
+  if (!normalized) return normalized;
 
-export async function getCalendarClient() {
-  const auth = googleAuth(CALENDAR_SCOPES);
-  const client = await auth.getClient();
-  return google.calendar({ version: 'v3', auth: client });
+  try {
+    const maybePem = Buffer.from(normalized, 'base64').toString('utf8');
+    if (maybePem.includes('BEGIN') && maybePem.includes('END')) {
+      return maybePem.replace(/\\n/g, '\n');
+    }
+  } catch {}
+
+  return normalized;
+}
+
+const GOOGLE_SA_EMAIL = process.env.GOOGLE_SA_EMAIL!;
+const GOOGLE_SA_KEY = normalizeKey(process.env.GOOGLE_SA_KEY || '');
+
+export function getSaJwt(scopes: string[]) {
+  return new JWT({
+    email: GOOGLE_SA_EMAIL,
+    key: GOOGLE_SA_KEY,
+    scopes,
+  });
 }

--- a/src/services/drive.ts
+++ b/src/services/drive.ts
@@ -1,24 +1,46 @@
-import { google } from 'googleapis';
-import { googleAuth } from './googleClient.js';
+import { google, drive_v3 } from 'googleapis';
+import { getSaJwt } from '../../server/utils/googleClient.js';
 
 const DRIVE_SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
 
-export async function getDriveClient() {
-  const auth = googleAuth(DRIVE_SCOPES);
-  const client = await auth.getClient();
-  return google.drive({ version: 'v3', auth: client });
+export function getDriveClient() {
+  const auth = getSaJwt(DRIVE_SCOPES);
+  return google.drive({ version: 'v3', auth });
 }
 
+type DriveMediaItem = {
+  id: string;
+  name: string;
+  mimeType: string;
+  sizeBytes?: number;
+  modifiedTime?: string;
+  thumbnailLink?: string;
+  webContentLink?: string;
+  iconLink?: string;
+};
+
 export async function listDriveMedia(folderId: string, _ctx: { userId: string }) {
-  const drive = await getDriveClient();
-  const response = await drive.files.list({
+  const drive = getDriveClient();
+  const resp = await drive.files.list({
     q: `'${folderId}' in parents and trashed = false`,
-    fields: 'files(id,name,mimeType,size,modifiedTime,thumbnailLink,webContentLink,webViewLink)',
+    fields: 'files(id,name,mimeType,size,modifiedTime,thumbnailLink,webContentLink,iconLink)',
     pageSize: 1000,
     supportsAllDrives: true,
     includeItemsFromAllDrives: true,
-    corpora: 'allDrives',
   });
 
-  return response.data.files ?? [];
+  const files = (resp.data.files ?? []) as drive_v3.Schema$File[];
+
+  return files
+    .filter((f): f is drive_v3.Schema$File & { id: string } => typeof f.id === 'string')
+    .map<DriveMediaItem>((f) => ({
+      id: f.id!,
+      name: f.name ?? '',
+      mimeType: f.mimeType ?? 'application/octet-stream',
+      sizeBytes: f.size ? Number(f.size) : undefined,
+      modifiedTime: f.modifiedTime ?? undefined,
+      thumbnailLink: f.thumbnailLink ?? undefined,
+      webContentLink: f.webContentLink ?? undefined,
+      iconLink: f.iconLink ?? undefined,
+    }));
 }


### PR DESCRIPTION
## Summary
- switch Drive and Calendar clients to a dedicated JWT service-account helper
- map Drive media results to a safe shape that handles optional fields
- update calendar routes to use the new calendar client wrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690239db7c50833399e84d9f0fc70816