### PR TITLE
Add app JWT minting support and JWKS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ API requests are authenticated with the InnerPeace app JWT. Set the issuer, audi
 | --- | --- |
 | `APP_JWT_ISSUER` | Issuer claim expected in app JWTs (default `https://innerpeace.app`). |
 | `APP_JWT_AUDIENCE` | Audience claim expected in app JWTs (default `innerpeace-app`). |
-| `APP_JWKS_URI` | HTTPS URL that serves the signing keys in JWKS format. |
+| `APP_JWKS_URI` | Optional override for the JWKS endpoint. Defaults to `<issuer>/.well-known/jwks.json`. |
+| `APP_JWT_PRIVATE_KEY_PEM` | PKCS#8 PEM used to mint first-party app tokens. |
+| `APP_JWT_PUBLIC_JWK` | Public JWK published at `/.well-known/jwks.json` for verifiers (safe to share). |
+| `APP_JWT_KID` | Key ID advertised in minted tokens and JWKS responses. |
 
 ## API Gateway authentication
 
 Protected endpoints are fronted by Google Cloud API Gateway. The OpenAPI definition in `infra/gateway/openapi-google.yaml` now defines an `app_jwt` security scheme that reads tokens from either the `x-app-jwt` header or the `Authorization: Bearer` header.
+
+The API publishes its signing keys at `/.well-known/jwks.json` and exposes `POST /auth/mint` for clients that need to exchange a federated identity for an Innerpeace app JWT. Ensure the same issuer domain fronts both endpoints so Cloud API Gateway can fetch the JWKS.
 
 To roll out changes, update the API config and redeploy the gateway:
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,6 +6,8 @@ import { listBookings } from './routes/bookings.js';
 import mediaRouter from './routes/media.js';
 import { requireAuth } from './middleware/auth.js';
 import youtubeRouter from './routes/youtube.js';
+import jwksRoute from './routes/jwks.js';
+import authMint from './routes/authMint.js';
 import { devLoggerMiddleware } from './middleware/devLogger.js';
 import { readProviderContext, requestLogMiddleware } from './middleware/requestContext.js';
 
@@ -34,6 +36,9 @@ if (process.env.NODE_ENV !== 'production') {
     res.sendStatus(404);
   });
 }
+
+app.use(jwksRoute);
+app.use(authMint);
 
 app.use('/api/media', mediaRouter);
 app.use('/api/youtube', youtubeRouter);

--- a/server/auth/appJwt.ts
+++ b/server/auth/appJwt.ts
@@ -1,0 +1,75 @@
+import { SignJWT, importPKCS8, type KeyLike } from 'jose';
+
+type SupportedAlg = 'ES256' | 'RS256';
+
+const ISS = process.env.APP_JWT_ISSUER || 'https://innerpeace.app';
+const AUD = process.env.APP_JWT_AUDIENCE || 'innerpeace-app';
+const KID = process.env.APP_JWT_KID;
+const PRIVATE_PEM = process.env.APP_JWT_PRIVATE_KEY_PEM;
+
+let cachedKey: KeyLike | null = null;
+let cachedAlg: SupportedAlg | null = null;
+
+function inferAlgorithm(pem: string): SupportedAlg {
+  if (pem.includes('EC PRIVATE KEY')) {
+    return 'ES256';
+  }
+
+  if (pem.includes('BEGIN RSA PRIVATE KEY')) {
+    return 'RS256';
+  }
+
+  if (pem.includes('BEGIN PRIVATE KEY')) {
+    // PKCS#8 wrapper – default to ES256 unless explicitly marked RSA.
+    return pem.includes('RSA') ? 'RS256' : 'ES256';
+  }
+
+  return 'RS256';
+}
+
+async function getSigningMaterial(): Promise<{ key: KeyLike; alg: SupportedAlg; kid: string }> {
+  const pem = PRIVATE_PEM;
+  if (!pem) {
+    throw new Error('APP_JWT_PRIVATE_KEY_PEM is not configured');
+  }
+
+  const kid = KID;
+  if (!kid) {
+    throw new Error('APP_JWT_KID is not configured');
+  }
+
+  if (!cachedKey) {
+    cachedAlg = inferAlgorithm(pem);
+    cachedKey = await importPKCS8(pem, cachedAlg);
+  }
+
+  if (!cachedAlg) {
+    cachedAlg = inferAlgorithm(pem);
+  }
+
+  return { key: cachedKey, alg: cachedAlg, kid };
+}
+
+export type AppJwtClaims = {
+  sub: string;
+  email?: string;
+  provider?: 'google' | 'apple' | string;
+  roles?: string[];
+};
+
+export async function mintAppJwt(claims: AppJwtClaims, ttlSec = 3600): Promise<string> {
+  if (!claims || typeof claims.sub !== 'string' || claims.sub.length === 0) {
+    throw new Error('claims.sub is required');
+  }
+
+  const { key, alg, kid } = await getSigningMaterial();
+  const now = Math.floor(Date.now() / 1000);
+
+  return await new SignJWT({ ...claims })
+    .setProtectedHeader({ alg, kid, typ: 'JWT' })
+    .setIssuer(ISS)
+    .setAudience(AUD)
+    .setIssuedAt(now)
+    .setExpirationTime(now + ttlSec)
+    .sign(key);
+}

--- a/server/routes/authMint.ts
+++ b/server/routes/authMint.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { mintAppJwt } from '../auth/appJwt.js';
+
+const router = Router();
+
+router.post('/auth/mint', async (req, res) => {
+  try {
+    const { sub, email, provider, roles, ttlSec } = req.body ?? {};
+
+    if (typeof sub !== 'string' || sub.length === 0) {
+      return res.status(400).json({ code: 400, message: 'sub required' });
+    }
+
+    if (ttlSec !== undefined && typeof ttlSec !== 'number') {
+      return res.status(400).json({ code: 400, message: 'ttlSec must be a number' });
+    }
+
+    if (roles !== undefined) {
+      const isValidRoles = Array.isArray(roles) && roles.every((role) => typeof role === 'string');
+      if (!isValidRoles) {
+        return res.status(400).json({ code: 400, message: 'roles must be an array of strings' });
+      }
+    }
+
+    const token = await mintAppJwt({ sub, email, provider, roles }, ttlSec ?? 3600);
+    return res.status(200).json({ token });
+  } catch (error) {
+    return res.status(500).json({ code: 500, message: 'Failed to mint JWT' });
+  }
+});
+
+export default router;

--- a/server/routes/jwks.ts
+++ b/server/routes/jwks.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/.well-known/jwks.json', (_req, res) => {
+  try {
+    const jwkRaw = process.env.APP_JWT_PUBLIC_JWK;
+    const kid = process.env.APP_JWT_KID;
+
+    if (!jwkRaw) {
+      throw new Error('APP_JWT_PUBLIC_JWK is not configured');
+    }
+
+    if (!kid) {
+      throw new Error('APP_JWT_KID is not configured');
+    }
+
+    const jwk = JSON.parse(jwkRaw);
+
+    if (!jwk || typeof jwk !== 'object' || Array.isArray(jwk)) {
+      throw new Error('Public JWK must be an object');
+    }
+
+    if (!('kid' in jwk) || !jwk.kid) {
+      (jwk as Record<string, unknown>).kid = kid;
+    }
+
+    res.setHeader('content-type', 'application/json');
+    res.status(200).json({ keys: [jwk] });
+  } catch (error) {
+    res.status(500).json({ error: 'JWKS unavailable' });
+  }
+});
+
+export default router;

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -2,7 +2,13 @@ import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
 
 const APP_JWT_ISSUER = process.env.APP_JWT_ISSUER || 'https://innerpeace.app';
 const APP_JWT_AUDIENCE = process.env.APP_JWT_AUDIENCE || 'innerpeace-app';
-const APP_JWKS_URI = process.env.APP_JWKS_URI || 'https://innerpeace.app/.well-known/jwks.json';
+
+function buildDefaultJwksUri(issuer: string): string {
+  const trimmed = issuer.replace(/\/+$/, '');
+  return `${trimmed}/.well-known/jwks.json`;
+}
+
+const APP_JWKS_URI = process.env.APP_JWKS_URI || buildDefaultJwksUri(APP_JWT_ISSUER);
 
 const jwks = createRemoteJWKSet(new URL(APP_JWKS_URI));
 


### PR DESCRIPTION
## Summary
- add a reusable signer that mints Innerpeace app JWTs using the configured private key
- expose /.well-known/jwks.json and /auth/mint routes so the gateway and clients can obtain signing metadata
- document the new authentication environment variables and align backend JWKS discovery with the configured issuer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69023e7f24848333b6ae4dccee4bbb89