### PR TITLE
Gracefully handle missing Supabase and Google credentials

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -2,16 +2,26 @@
 import type { Request, Response, NextFunction } from 'express';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-const PROJECT_REF = process.env.SUPABASE_PROJECT_REF;
-if (!PROJECT_REF) {
-  throw new Error('SUPABASE_PROJECT_REF is not configured');
-}
-const SUPABASE_ISS = `https://${PROJECT_REF}.supabase.co/auth/v1`;
-const SUPABASE_JWKS = `${SUPABASE_ISS}/keys`;
+const projectRef = process.env.SUPABASE_PROJECT_REF?.trim();
 const SUPABASE_AUD = process.env.SUPABASE_AUD || 'authenticated';
-
-const jwks = createRemoteJWKSet(new URL(SUPABASE_JWKS));
 const isLocal = process.env.NODE_ENV !== 'production';
+
+interface SupabaseAuthConfig {
+  issuer: string;
+  jwks: ReturnType<typeof createRemoteJWKSet>;
+}
+
+let supabaseConfig: SupabaseAuthConfig | null = null;
+
+if (projectRef) {
+  const issuer = `https://${projectRef}.supabase.co/auth/v1`;
+  supabaseConfig = {
+    issuer,
+    jwks: createRemoteJWKSet(new URL(`${issuer}/keys`)),
+  };
+} else {
+  console.warn('[auth] SUPABASE_PROJECT_REF is not configured. requireAuth will reject requests until it is set.');
+}
 
 declare global {
   namespace Express {
@@ -31,6 +41,10 @@ declare global {
  */
 export async function requireAuth(req: Request, res: Response, next: NextFunction) {
   try {
+    if (!supabaseConfig) {
+      return res.status(500).json({ code: 500, message: 'Supabase authentication is not configured' });
+    }
+
     // 1) Trust ESP user info header if present
     const userInfoB64 = req.header('x-endpoint-api-userinfo');
     if (userInfoB64) {
@@ -44,7 +58,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       const auth = req.header('authorization') || req.header('Authorization') || '';
       const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
       if (!token) return res.status(401).json({ code: 401, message: 'Missing Authorization' });
-      const { payload } = await jwtVerify(token, jwks, { issuer: SUPABASE_ISS, audience: SUPABASE_AUD });
+      const { payload } = await jwtVerify(token, supabaseConfig.jwks, {
+        issuer: supabaseConfig.issuer,
+        audience: SUPABASE_AUD,
+      });
       req.user = payload as any;
       return next();
     }


### PR DESCRIPTION
## Summary
- avoid crashing on startup when Supabase project ref is missing by deferring configuration checks to request time
- defer Google service account validation until credentials are actually requested and memoize the decoded key
- add clear error responses and console warnings so misconfigurations are surfaced without preventing deployment

## Testing
- npm run build
- npm test *(fails: Directory /workspace/innerpeace-api/tests in the roots[0] option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_69028c8598b883339fde743a0b945517