### PR TITLE
Use service account for media listings

### DIFF
--- a/infra/gateway/openapi-google.yaml
+++ b/infra/gateway/openapi-google.yaml
@@ -27,6 +27,31 @@ paths:
       responses:
         "204": { description: "CORS preflight" }
 
+  /api/media/list:
+    get:
+      operationId: listMedia
+      x-google-allowWithoutApiKey: true
+      x-google-backend:
+        address: "https://innerpeace-api-379484922687.europe-west2.run.app"
+        path_translation: APPEND_PATH_TO_ADDRESS
+      parameters:
+        - name: folderId
+          in: query
+          required: true
+          type: string
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+      responses:
+        "200": { description: "OK" }
+        "400": { description: "Missing folderId" }
+        "401": { description: "Unauthorized" }
+
   /api/{path=**}:
     get:
       operationId: passthroughGet

--- a/src/http/media.ts
+++ b/src/http/media.ts
@@ -1,0 +1,66 @@
+import crypto from 'node:crypto';
+import type { Request, Response } from 'express';
+import { extractBearerToken, verifySupabaseJwt } from '../lib/supabaseJwt.js';
+import { listDriveMedia } from '../services/drive.js';
+
+export async function listMediaHandler(req: Request, res: Response) {
+  const folderId = req.query.folderId as string | undefined;
+  const pageToken = (req.query.pageToken as string) || undefined;
+  const pageSizeRaw = (req.query.pageSize as string) || undefined;
+  const parsedPageSize = pageSizeRaw ? Number.parseInt(pageSizeRaw, 10) : 50;
+  const pageSize = Math.min(Math.max(Number.isFinite(parsedPageSize) ? parsedPageSize : 50, 1), 200);
+
+  const token = extractBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ code: 401, message: 'Unauthorized' });
+  }
+
+  try {
+    verifySupabaseJwt(token);
+  } catch (error) {
+    return res.status(401).json({ code: 401, message: 'Unauthorized' });
+  }
+
+  if (!folderId) {
+    return res.status(400).json({ code: 400, message: 'Missing folderId' });
+  }
+
+  try {
+    const { files, nextPageToken } = await listDriveMedia(folderId, { pageToken, pageSize });
+    const items = files.map((file) => ({
+      id: file.id!,
+      name: file.name ?? '',
+      mimeType: file.mimeType ?? 'application/octet-stream',
+      size: file.size ? Number(file.size) : undefined,
+      md5: file.md5Checksum ?? null,
+      modifiedTime: file.modifiedTime ?? null,
+      createdTime: file.createdTime ?? null,
+      streamUrl: `/api/media/stream/${file.id}`,
+      icon: file.iconLink ?? null,
+      thumb: file.thumbnailLink ?? null,
+    }));
+
+    console.log('[BE]/api/media/list', {
+      folderId,
+      count: items.length,
+      sample: items.slice(0, 3).map(({ id, name }) => ({ id, name })),
+    });
+
+    const etag = crypto
+      .createHash('sha1')
+      .update(items.map((i) => `${i.id}:${i.md5 ?? ''}:${i.modifiedTime ?? ''}`).join('|'))
+      .digest('hex');
+
+    const noStore = process.env.MEDIA_LIST_NO_STORE === 'true';
+    res.set(
+      noStore
+        ? { 'Cache-Control': 'no-store' }
+        : { 'Cache-Control': 'public, max-age=60', ETag: `"media-list-${etag}"` }
+    );
+
+    return res.json({ items, nextPageToken });
+  } catch (error) {
+    console.error('[media.list] error', (error as any)?.response?.data || error);
+    return res.status(500).json({ code: 500, message: 'Drive list failed' });
+  }
+}

--- a/src/lib/drive.ts
+++ b/src/lib/drive.ts
@@ -1,9 +1,0 @@
-import { google } from 'googleapis';
-
-// Uses Application Default Credentials on Cloud Run
-export function driveClient() {
-  const auth = new google.auth.GoogleAuth({
-    scopes: ['https://www.googleapis.com/auth/drive.readonly'],
-  });
-  return google.drive({ version: 'v3', auth });
-}

--- a/src/lib/supabaseJwt.ts
+++ b/src/lib/supabaseJwt.ts
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+import type { Request } from 'express';
+
+export type SupabaseJwtPayload = jwt.JwtPayload & { sub?: string };
+
+function ensureSecret(): string {
+  const secret = process.env.SUPABASE_JWT_SECRET;
+  if (!secret) {
+    throw new Error('SUPABASE_JWT_SECRET is not configured.');
+  }
+  return secret;
+}
+
+const BEARER_HEADER_CANDIDATES = [
+  'X-Forwarded-Authorization',
+  'x-forwarded-authorization',
+  'Authorization',
+  'authorization',
+];
+
+export function extractBearerToken(req: Pick<Request, 'header'>): string | null {
+  for (const header of BEARER_HEADER_CANDIDATES) {
+    const value = req.header(header) || '';
+    if (typeof value === 'string' && value.startsWith('Bearer ')) {
+      return value.slice(7);
+    }
+  }
+  return null;
+}
+
+export function verifySupabaseJwt(token: string): SupabaseJwtPayload {
+  const secret = ensureSecret();
+  const verified = jwt.verify(token, secret, { algorithms: ['HS256'] });
+  if (typeof verified === 'string') {
+    const decoded = jwt.decode(token);
+    if (!decoded || typeof decoded === 'string') {
+      throw new Error('Failed to decode Supabase JWT payload.');
+    }
+    return decoded as SupabaseJwtPayload;
+  }
+  return verified as SupabaseJwtPayload;
+}

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,80 +1,13 @@
 import { Router } from 'express';
-import crypto from 'crypto';
-import type { drive_v3 } from 'googleapis';
+import { listMediaHandler } from '../http/media.js';
+import { extractBearerToken, verifySupabaseJwt } from '../lib/supabaseJwt.js';
 import { signStreamToken, verifyStreamToken } from '../lib/streamToken.js';
 import { requireSupabaseAuth } from '../middleware/auth.js';
-import { driveClient } from '../lib/drive.js';
-
-type MediaItem = {
-  id: string;
-  name: string;
-  mimeType: string;
-  size?: number;
-  md5?: string | null;
-  modifiedTime?: string | null;
-  createdTime?: string | null;
-  streamUrl: string;
-  icon?: string | null;
-  thumb?: string | null;
-};
+import { getDriveClient } from '../services/drive.js';
 
 const router = Router();
 
-router.get('/list', requireSupabaseAuth, async (req, res) => {
-  const folderId = req.query.folderId as string;
-  const pageToken = (req.query.pageToken as string) || undefined;
-  const pageSize = Math.min(parseInt((req.query.pageSize as string) || '50', 10), 200);
-  if (!folderId) return res.status(400).json({ code: 400, message: 'Missing folderId' });
-
-  try {
-    const drive = driveClient();
-    const { data } = await drive.files.list({
-      q: `'${folderId}' in parents and trashed = false and (mimeType contains 'audio/' or mimeType='audio/mpeg' or mimeType='audio/mp4' or mimeType='audio/x-m4a' or mimeType='audio/wav')`,
-      fields: 'nextPageToken, files(id,name,mimeType,size,md5Checksum,modifiedTime,createdTime,iconLink,thumbnailLink)',
-      orderBy: 'modifiedTime desc',
-      pageToken,
-      pageSize,
-      supportsAllDrives: true,
-      includeItemsFromAllDrives: true,
-      corpora: 'allDrives',
-    });
-
-    const items: MediaItem[] = (data.files || []).map((file: drive_v3.Schema$File) => ({
-      id: file.id!,
-      name: file.name!,
-      mimeType: file.mimeType!,
-      size: file.size ? Number(file.size) : undefined,
-      md5: file.md5Checksum,
-      modifiedTime: file.modifiedTime,
-      createdTime: file.createdTime,
-      streamUrl: `/api/media/stream/${file.id}`,
-      icon: file.iconLink,
-      thumb: file.thumbnailLink,
-    }));
-
-    console.log('[BE]/api/media/list', {
-      folderId,
-      count: items.length,
-      sample: items.slice(0, 3).map(({ id, name }) => ({ id, name })),
-    });
-
-    const etag = crypto
-      .createHash('sha1')
-      .update(items.map((i) => `${i.id}:${i.md5 ?? ''}:${i.modifiedTime ?? ''}`).join('|'))
-      .digest('hex');
-    const noStore = process.env.MEDIA_LIST_NO_STORE === 'true';
-    res.set(
-      noStore
-        ? { 'Cache-Control': 'no-store' }
-        : { 'Cache-Control': 'public, max-age=60', ETag: `"media-list-${etag}"` }
-    );
-
-    return res.json({ items, nextPageToken: data.nextPageToken || null });
-  } catch (e: any) {
-    console.error('[media.list] error', e?.response?.data || e);
-    return res.status(500).json({ code: 500, message: 'Drive list failed' });
-  }
-});
+router.get('/list', listMediaHandler);
 
 router.get('/play/:id', requireSupabaseAuth, (req, res) => {
   const fileId = req.params.id;
@@ -97,11 +30,16 @@ router.get('/stream/:id', async (req, res) => {
   const p = tok ? verifyStreamToken(tok) : null;
   if (p && p.id === fileId) allowed = true;
   if (!allowed) {
-    const b = req.header('X-Forwarded-Authorization') || req.header('Authorization') || '';
-    if (!b.startsWith('Bearer ')) return res.status(401).json({ code: 401, message: 'Unauthorized' });
+    const bearer = extractBearerToken(req);
+    if (!bearer) return res.status(401).json({ code: 401, message: 'Unauthorized' });
+    try {
+      verifySupabaseJwt(bearer);
+    } catch {
+      return res.status(401).json({ code: 401, message: 'Unauthorized' });
+    }
     allowed = true;
   }
-  const drive = driveClient();
+  const drive = getDriveClient();
   const meta = await drive.files.get({
     fileId,
     fields: 'id,name,mimeType,size,md5Checksum,modifiedTime',


### PR DESCRIPTION
## Summary
- add Supabase JWT helpers and media handler that validates app sessions before listing Drive media
- reuse the service-account Drive client for media APIs and update streaming auth to honour Supabase tokens
- document the media list endpoint in the API gateway OpenAPI definition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690390dbed508333a2531024e86152a1