### PR TITLE
Fix auth routing loop by centralizing navigation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,34 @@
+import { Stack, usePathname, useRouter, useSegments } from 'expo-router';
+import React, { useEffect } from 'react';
+import { useAuthStore } from '../src/stores/auth';
+
+// ONE: Layout decides navigation. Screens never redirect.
+export default function RootLayout() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const segments = useSegments();
+
+  const { checked, session, initialize } = useAuthStore();
+
+  // Initialize Supabase auth listener once.
+  useEffect(() => { void initialize(); }, []);
+
+  // Gate after auth is known. Only navigate when the target differs.
+  useEffect(() => {
+    if (!checked) return;
+    const authed = !!session;
+
+    // treat /login (and optional (auth) group) as auth routes
+    const inAuthZone =
+      pathname === '/login' || segments[0] === '(auth)';
+
+    if (!authed && !inAuthZone && pathname !== '/login') {
+      router.replace('/login');
+    } else if (authed && inAuthZone && pathname !== '/') {
+      router.replace('/');
+    }
+  }, [checked, session, pathname, segments, router]);
+
+  // Render the navigator. No Slot. No state changes here.
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { signOutAll } from '../src/auth/native';
+
+export default function Home() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 24 }}>
+      <Text style={{ fontSize: 22, textAlign: 'center', marginBottom: 24 }}>
+        Welcome to InnerPeace
+      </Text>
+      <Pressable
+        onPress={() => signOutAll()}
+        style={{ padding: 14, borderRadius: 12, backgroundColor: '#eee' }}
+      >
+        <Text style={{ textAlign: 'center' }}>Sign out</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { signInWithAppleNative, signInWithGoogleNative } from '../src/auth/native';
+
+export default function Login() {
+  const [busy, setBusy] = useState<'google' | 'apple' | null>(null);
+
+  const run = async (provider: 'google' | 'apple') => {
+    try {
+      setBusy(provider);
+      if (provider === 'google') await signInWithGoogleNative();
+      else await signInWithAppleNative();
+      // Do not navigate here; layout will redirect once session exists.
+    } catch (e: any) {
+      Alert.alert(
+        `${provider === 'google' ? 'Google' : 'Apple'} Sign-In failed`,
+        e?.message ?? 'Unknown error'
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 24 }}>
+      <Text style={{ fontSize: 28, textAlign: 'center', marginBottom: 24 }}>InnerPeace</Text>
+
+      <Pressable
+        onPress={() => run('google')}
+        style={{ padding: 14, borderRadius: 12, backgroundColor: '#fff', marginBottom: 12 }}
+      >
+        {busy === 'google'
+          ? <ActivityIndicator />
+          : <Text style={{ textAlign: 'center' }}>Continue with Google</Text>}
+      </Pressable>
+
+      <Pressable
+        onPress={() => run('apple')}
+        style={{ padding: 14, borderRadius: 12, backgroundColor: '#000' }}
+      >
+        {busy === 'apple'
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={{ color: '#fff', textAlign: 'center' }}>Sign in with Apple</Text>}
+      </Pressable>
+    </View>
+  );
+}

--- a/src/auth/native.ts
+++ b/src/auth/native.ts
@@ -1,0 +1,55 @@
+import * as Apple from 'expo-apple-authentication';
+import * as AuthSession from 'expo-auth-session';
+import { supabase } from '../lib/supabase';
+
+const GOOGLE_NATIVE_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_NATIVE_CLIENT_ID!;
+
+function nonce(len = 32) {
+  const cs = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let s = '';
+  for (let i = 0; i < len; i++) s += cs[Math.floor(Math.random() * cs.length)];
+  return s;
+}
+
+export async function signInWithAppleNative() {
+  const rawNonce = nonce();
+  const cred = await Apple.signInAsync({
+    requestedScopes: [Apple.AppleAuthenticationScope.FULL_NAME, Apple.AppleAuthenticationScope.EMAIL],
+    nonce: rawNonce,
+  });
+  if (!cred.identityToken) throw new Error('No Apple identityToken');
+  const { error } = await supabase.auth.signInWithIdToken({
+    provider: 'apple',
+    token: cred.identityToken,
+    nonce: rawNonce,
+  });
+  if (error) throw error;
+}
+
+export async function signInWithGoogleNative() {
+  const discovery = {
+    authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenEndpoint: 'https://oauth2.googleapis.com/token',
+  } as const;
+
+  const req = new AuthSession.AuthRequest({
+    clientId: GOOGLE_NATIVE_CLIENT_ID,
+    responseType: AuthSession.ResponseType.IdToken,
+    scopes: ['openid', 'email', 'profile'],
+    extraParams: { prompt: 'select_account' },
+  });
+
+  await req.makeAuthUrlAsync(discovery);
+  const res = await req.promptAsync(discovery, { useProxy: false });
+  if (res.type !== 'success' || !res.params.id_token) throw new Error('No Google id_token');
+
+  const { error } = await supabase.auth.signInWithIdToken({
+    provider: 'google',
+    token: res.params.id_token,
+  });
+  if (error) throw error;
+}
+
+export async function signOutAll() {
+  await supabase.auth.signOut();
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,14 @@
+import 'react-native-url-polyfill/auto';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.EXPO_PUBLIC_SUPABASE_URL!;
+const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(url, key, {
+  auth: {
+    flowType: 'pkce',
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false, // native
+  },
+});

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+type S = { checked: boolean; session: Session | null; user: User | null };
+type A = { initialize: () => Promise<void> };
+
+export const useAuthStore = create<S & A>((set) => ({
+  checked: false,
+  session: null,
+  user: null,
+  initialize: async () => {
+    const { data } = await supabase.auth.getSession();
+    set({ checked: true, session: data.session ?? null, user: data.session?.user ?? null });
+    supabase.auth.onAuthStateChange((_e, sess) => {
+      set({ checked: true, session: sess ?? null, user: sess?.user ?? null });
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- centralize navigation control in `app/_layout.tsx` so only the layout drives redirects
- simplify the home and login screens to rely on the shared auth store without inline navigation
- add Supabase helpers and a zustand auth store to coordinate session state

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_6903f5665ff88333be54ce87410837ee