### PR TITLE
Use ADC for Drive access and add health check

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -10,7 +10,7 @@ SEND_UPDATES=all
 BOOK_ORGANIZER_MODE=manager
 
 # Media proxy configuration
-DRIVE_MEDIA_FOLDER_ID=1dQYrV3DFjJJB53Gn2ueN2tPY804dHCZm
+MEDIA_FOLDER_ID=1dQYrV3DFjJJB53Gn2ueN2tPY804dHCZm
 MEDIA_ALLOWED_MIME=video/*,audio/*
 MEDIA_CACHE_MAX_AGE=public, max-age=3600
 
@@ -19,6 +19,8 @@ SUPABASE_PROJECT_REF=abcd1234
 SUPABASE_AUD=authenticated
 
 # Service account credentials
-GOOGLE_SA_EMAIL=run-innerpeace-sa@innerpeace-app-471115.iam.gserviceaccount.com
-# GOOGLE_SA_KEY should contain the raw PEM or base64-encoded key
-GOOGLE_SA_KEY=
+# Local-only (optional). Do NOT set these in Cloud Run if using ADC.
+# GOOGLE_SA_JSON={"client_email":"...","private_key":"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"}
+# or:
+# GOOGLE_SA_EMAIL=drive-bot@innerpeace-app-471115.iam.gserviceaccount.com
+# GOOGLE_SA_KEY=-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,6 +6,7 @@ import bookingsRoutes from './routes/bookings.js';
 import availabilityRoutes from './routes/availability.js';
 import youtubeRouter from './routes/youtube.js';
 import { devLoggerMiddleware } from './middleware/devLogger.js';
+import healthRoutes from './routes/health.js';
 
 const app = express();
 
@@ -19,6 +20,7 @@ app.use(devLoggerMiddleware());
 
 // Public endpoints
 app.get('/healthz', (_req, res) => res.status(200).send('ok'));
+app.use(healthRoutes);
 app.use('/youtube', youtubeRouter);
 app.use('/api/youtube', youtubeRouter);
 

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/routes/health.js';

--- a/server/utils/googleClient.ts
+++ b/server/utils/googleClient.ts
@@ -48,8 +48,7 @@ function resolveServiceAccount(): ServiceAccount {
   const jsonCandidate =
     process.env.GOOGLE_SA_JSON ||
     process.env.GOOGLE_SERVICE_ACCOUNT_JSON ||
-    process.env.GOOGLE_SA_CREDENTIALS ||
-    process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+    process.env.GOOGLE_SA_CREDENTIALS;
 
   const parsed = parseServiceAccountJson(jsonCandidate);
   if (parsed) {

--- a/src/google/drive.ts
+++ b/src/google/drive.ts
@@ -1,0 +1,41 @@
+import { google, type drive_v3 } from 'googleapis';
+import { GoogleAuth } from 'google-auth-library';
+
+const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
+
+let cachedDrive: drive_v3.Drive | null = null;
+
+export async function getDrive() {
+  if (cachedDrive) {
+    return cachedDrive;
+  }
+
+  const json = process.env.GOOGLE_SA_JSON;
+  if (json) {
+    const { client_email, private_key } = JSON.parse(json);
+    const auth = new google.auth.JWT({
+      email: client_email,
+      key: private_key,
+      scopes: SCOPES,
+    });
+    cachedDrive = google.drive({ version: 'v3', auth });
+    return cachedDrive;
+  }
+
+  const email = process.env.GOOGLE_SA_EMAIL;
+  const key = process.env.GOOGLE_SA_KEY;
+  if (email && key) {
+    const auth = new google.auth.JWT({
+      email,
+      key: key.replace(/\\n/g, '\n'),
+      scopes: SCOPES,
+    });
+    cachedDrive = google.drive({ version: 'v3', auth });
+    return cachedDrive;
+  }
+
+  const auth = new GoogleAuth({ scopes: SCOPES });
+  await auth.getClient();
+  cachedDrive = google.drive({ version: 'v3', auth });
+  return cachedDrive;
+}

--- a/src/http/media.ts
+++ b/src/http/media.ts
@@ -4,7 +4,10 @@ import { extractBearerToken, verifySupabaseJwt } from '../lib/supabaseJwt.js';
 import { listDriveMedia } from '../services/drive.js';
 
 export async function listMediaHandler(req: Request, res: Response) {
-  const folderId = req.query.folderId as string | undefined;
+  const folderId =
+    (req.query.folderId as string) ||
+    process.env.MEDIA_FOLDER_ID ||
+    process.env.DRIVE_MEDIA_FOLDER_ID;
   const pageToken = (req.query.pageToken as string) || undefined;
   const pageSizeRaw = (req.query.pageSize as string) || undefined;
   const parsedPageSize = pageSizeRaw ? Number.parseInt(pageSizeRaw, 10) : 50;
@@ -22,7 +25,7 @@ export async function listMediaHandler(req: Request, res: Response) {
   }
 
   if (!folderId) {
-    return res.status(400).json({ code: 400, message: 'Missing folderId' });
+    return res.status(400).json({ code: 400, message: 'folderId required' });
   }
 
   try {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { getDrive } from '../google/drive.js';
+
+const router = Router();
+
+router.get('/health/drive', async (_req, res) => {
+  try {
+    const drive = await getDrive();
+    await drive.files.list({ pageSize: 1, fields: 'files(id)' });
+    return res.json({ ok: true });
+  } catch (e: any) {
+    console.error('[health.drive] error', e?.message || e);
+    return res.status(500).json({ ok: false, error: e?.message || 'failed' });
+  }
+});
+
+export default router;

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -3,7 +3,7 @@ import { listMediaHandler } from '../http/media.js';
 import { extractBearerToken, verifySupabaseJwt } from '../lib/supabaseJwt.js';
 import { signStreamToken, verifyStreamToken } from '../lib/streamToken.js';
 import { requireSupabaseAuth } from '../middleware/auth.js';
-import { getDriveClient } from '../services/drive.js';
+import { getDrive } from '../google/drive.js';
 
 const router = Router();
 
@@ -39,7 +39,7 @@ router.get('/stream/:id', async (req, res) => {
     }
     allowed = true;
   }
-  const drive = getDriveClient();
+  const drive = await getDrive();
   const meta = await drive.files.get({
     fileId,
     fields: 'id,name,mimeType,size,md5Checksum,modifiedTime',

--- a/src/services/drive.ts
+++ b/src/services/drive.ts
@@ -1,19 +1,5 @@
-import { google, type drive_v3 } from 'googleapis';
-import { getSaJwt } from '../../server/utils/googleClient.js';
-
-const DRIVE_SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
-
-let cachedClient: drive_v3.Drive | null = null;
-
-export function getDriveClient() {
-  if (cachedClient) {
-    return cachedClient;
-  }
-
-  const auth = getSaJwt(DRIVE_SCOPES);
-  cachedClient = google.drive({ version: 'v3', auth });
-  return cachedClient;
-}
+import type { drive_v3 } from 'googleapis';
+import { getDrive } from '../google/drive.js';
 
 export interface ListDriveMediaOptions {
   pageToken?: string;
@@ -30,7 +16,7 @@ export async function listDriveMedia(
   folderId: string,
   { pageToken, pageSize, mimeTypes }: ListDriveMediaOptions = {}
 ): Promise<ListDriveMediaResult> {
-  const drive = getDriveClient();
+  const drive = await getDrive();
   const safeFolderId = folderId.replace(/'/g, "\\'");
   const filters = (mimeTypes && mimeTypes.length ? mimeTypes : null) || [
     "mimeType contains 'audio/'",


### PR DESCRIPTION
## Summary
- add a Google Drive helper that defaults to Application Default Credentials while still supporting explicit service account env vars
- update media handlers to use the shared helper, allow MEDIA_FOLDER_ID fallback, and expose a /health/drive probe
- document the credential expectations in .env.local and remove GOOGLE_APPLICATION_CREDENTIALS usage

## Testing
- npm run build *(fails: missing expo-apple-authentication/expo-auth-session/@supabase/supabase-js/zustand dev deps in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6904c8c008c48333b0385068374c1497