### PR TITLE
Fix Drive helper ADC client typing

### DIFF
--- a/src/google/drive.ts
+++ b/src/google/drive.ts
@@ -35,7 +35,7 @@ export async function getDrive() {
   }
 
   const auth = new GoogleAuth({ scopes: SCOPES });
-  await auth.getClient();
-  cachedDrive = google.drive({ version: 'v3', auth });
+  const client = (await auth.getClient()) as drive_v3.Options['auth'];
+  cachedDrive = google.drive({ version: 'v3', auth: client });
   return cachedDrive;
 }


### PR DESCRIPTION
## Summary
- cast the ADC client returned by GoogleAuth so the Drive helper can reuse it without TypeScript errors

## Testing
- npm run build *(fails: missing expo-apple-authentication, expo-auth-session, @supabase/supabase-js, and zustand dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6904cdbbe504833380dc0ac6847c3ebc