### PR TITLE
Exclude client-only modules from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,11 @@
     "sourceMap": true,
     "isolatedModules": true
   },
-  "include": ["server/**/*.ts", "server/**/*.d.ts", "src/**/*.ts", "src/**/*.d.ts"]
+  "include": ["server/**/*.ts", "server/**/*.d.ts", "src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": [
+    "src/auth/**/*",
+    "src/lib/supabase.ts",
+    "src/stores/**/*",
+    "app/**/*"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude Expo native auth, Supabase client, and store modules from the server TypeScript compilation
- prevent build failures caused by Expo-specific dependencies that are not available in the API build environment

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_6904d18bd2cc833390f2dd7caf668d6a