### PR TITLE
Improve Supabase auth middleware and server startup logging

### DIFF
--- a/src/middleware/requireUser.ts
+++ b/src/middleware/requireUser.ts
@@ -1,21 +1,42 @@
 import type { Request, Response, NextFunction } from 'express';
-import { supabaseAdmin } from '../supabase/admin.js';
+import { createClient } from '@supabase/supabase-js';
+import { unauthorized } from '../utils/http.js';
 
-function bearer(req: Request) {
-  const h = (req.headers.authorization || req.headers.Authorization) as string | undefined;
-  if (!h) return null;
-  const m = /^Bearer\s+(.+)$/i.exec(h);
-  return m?.[1] ?? null;
-}
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const supabase = (supabaseUrl && supabaseServiceRoleKey)
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+  : null;
 
 export async function requireUser(req: Request, res: Response, next: NextFunction) {
-  if (!supabaseAdmin) return res.status(401).json({ code: 401, message: 'Unauthorized' });
-  const token = bearer(req);
-  if (!token) return res.status(401).json({ code: 401, message: 'Unauthorized' });
+  try {
+    if (!supabase) {
+      console.error('[auth] SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not configured');
+      return res.status(500).json({ code: 500, message: 'Supabase auth not configured' });
+    }
 
-  const { data, error } = await supabaseAdmin.auth.getUser(token);
-  if (error || !data?.user) return res.status(401).json({ code: 401, message: 'Unauthorized' });
+    const hdr = (req.headers.authorization || (req.headers as any).Authorization) as string | undefined;
+    if (!hdr || !/^Bearer\s+/i.test(hdr)) {
+      return unauthorized(res);
+    }
 
-  (req as any).user = data.user;
-  return next();
+    const token = hdr.replace(/^Bearer\s+/i, '').trim();
+    if (!token) {
+      return unauthorized(res);
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return unauthorized(res);
+    }
+
+    (req as any).user = data.user;
+    return next();
+  } catch (e) {
+    console.error('[auth] requireUser failed:', (e as Error)?.message ?? e);
+    return unauthorized(res);
+  }
 }

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireUser } from '../middleware/requireUser.js';
 import { getDrive } from '../google/drive.js';
+import { badRequest } from '../utils/http.js';
 
 const r = Router();
 
@@ -11,7 +12,7 @@ r.get('/api/media/list', requireUser, async (req, res) => {
       process.env.MEDIA_FOLDER_ID ||
       process.env.DRIVE_MEDIA_FOLDER_ID;
 
-    if (!folderId) return res.status(400).json({ code: 400, message: 'folderId required' });
+    if (!folderId) return badRequest(res, 'folderId required');
 
     const drive = await getDrive();
     const resp = await drive.files.list({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,11 +1,29 @@
 import 'dotenv/config';
 import app from './app.js';
 
-const PORT = Number(process.env.PORT || 8080);
-const HOST = '0.0.0.0';
+const port = Number(process.env.PORT || 8080);
+const host = '0.0.0.0';
 
-const server = app.listen(PORT, HOST, () => {
-  console.log(`[server] listening on ${HOST}:${PORT}`);
+app.set('trust proxy', 1);
+
+if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  console.warn('[env] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY; protected routes will fail');
+}
+
+app.get('/healthz', (_req, res) => res.status(200).send('ok'));
+
+const server = app.listen(port, host, () => {
+  console.log(
+    JSON.stringify({
+      msg: 'server:start',
+      port,
+      host,
+      service: process.env.K_SERVICE || null,
+      region: process.env.K_REGION || null,
+      supabaseUrl: !!process.env.SUPABASE_URL,
+      hasServiceRole: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+    }),
+  );
 });
 
 // Log & exit so Cloud Run restarts cleanly if something truly explodes

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,4 @@
+export const unauthorized = (res: any) => res.status(401).json({ code: 401, message: 'Unauthorized' });
+
+export const badRequest = (res: any, message = 'Bad Request') =>
+  res.status(400).json({ code: 400, message });


### PR DESCRIPTION
## Summary
- replace the auth middleware with a Supabase service role client that validates bearer tokens and attaches the user to requests
- add shared HTTP helpers and reuse them in the media list route
- configure the server to trust the proxy, expose /healthz, and log startup metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6904f7ad86748333bcc6d85d1ac59469